### PR TITLE
Revert "Disable lazy loading on gallery"

### DIFF
--- a/src/components/Gallery/index.js
+++ b/src/components/Gallery/index.js
@@ -93,8 +93,6 @@ export default class Gallery extends React.Component {
               objectFit: "contain",
             }}
             fluid={imageData}
-            critical
-            fadeIn={false}
           />
           <div id="collapse-button-container">
             <div


### PR DESCRIPTION
Reverts Nrin3141/blog#15
It does not work :( 
Sadly the images are not being preloaded, all that is happening is that they are not loaded at all! - At least not until the component renders... that's sad :( 